### PR TITLE
Check for wallet.dat before attempting to back it up

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -542,8 +542,7 @@ bool AppInit2()
         }
         nWalletBackups = GetArg("-createwalletbackups", 10);
         nWalletBackups = std::max(0, std::min(10, nWalletBackups));
-        if(nWalletBackups > 0)
-        {
+        if(nWalletBackups > 0 && (filesystem::exists(GetDataDir() / strWalletFileName)))        {
             if (filesystem::exists(backupDir))
             {
                 // Create backup of the wallet


### PR DESCRIPTION
IF there is no existing wallet.dat currently the MacOS qt fails during an attempt to back up the wallet.dat 

this adds a check to check for wallet.dat before doing the backup